### PR TITLE
fix: use php.ini-development for gh actions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -62,6 +62,9 @@ runs:
         php-version: ${{ inputs.php-version }}
         extensions: ctype,curl,dom,gd,iconv,intl,json,mbstring,openssl,posix,sqlite,xml,zip,gmp
         coverage: ${{ inputs.php-coverage }}
+        ini-file: development
+        ini-values:
+          disable_functions= # https://github.com/shivammathur/setup-php/discussions/573
     - name: Install krankerl
       if: ${{ contains(inputs.tools, 'krankerl') }}
       shell: bash


### PR DESCRIPTION
By default setup-php uses php.ini-production.

production:
- zend.exception_ignore_args = On
- zend.exception_string_param_max_len = 0
- error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
- display_errors = Off
- display_startup_errors = Off
- mysqlnd.collect_memory_statistics = Off
- zend.assertions = -1

development:
- zend.exception_ignore_args = Off
- zend.exception_string_param_max_len = 15
- error_reporting = E_ALL
- display_errors = On
- display_startup_errors = On
- mysqlnd.collect_memory_statistics = On
- zend.assertions = 1

Most workflows in https://github.com/nextcloud/.github are using php.ini-development as well. 

The different error_reporting could explain, why some deprecation warnings are missing on our ci (e.g. PHP Deprecated:  Creation of dynamic property OCA\Mail\Tests\Unit\Controller\DraftsControllerTest::$smimeService is deprecated in tests/Unit/Controller/DraftsControllerTest.php on line 63)